### PR TITLE
Bugfix_import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,4 +107,14 @@ alabtools/geotools/geotools.py
 
 # Visual Studio Code settings
 .vscode/
+
+# Parallelization outputs
+*script1.sh
+*script_engines.sh
+*err_controller
+*out_controller
+*err_engines
+*out_engines
+*err_submit
+*out_submit
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,8 @@ ENV/
 *.png
 *.hcs
 *_wrap.c*
+*.ct
+*.ctenv
 
 alabtools/numutils.c
 alabtools/cmtools/cmtools.py

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ alabtools/cmtools/cmtools.py
 alabtools/geotools/geotools.py
 
 .idea/
+
+# Visual Studio Code settings
+.vscode/
+```

--- a/alabtools/__init__.py
+++ b/alabtools/__init__.py
@@ -12,7 +12,7 @@ from .utils import Genome, Index
 from .analysis import HssFile
 from . import plots, analysis
 
-from .imaging import CtFile
+from .imaging.ctfile import CtFile
 from .imaging.phasing import *
 from .imaging.ctenvelope import CtEnvelope
 

--- a/alabtools/__init__.py
+++ b/alabtools/__init__.py
@@ -12,8 +12,5 @@ from .utils import Genome, Index
 from .analysis import HssFile
 from . import plots, analysis
 
-from .imaging.ctfile import CtFile
-from .imaging.phasing import *
-from .imaging.ctenvelope import CtEnvelope
-
-from .parallel import Controller
+from . import imaging
+from . import parallel

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-from distutils.core import setup, Extension
+from setuptools import setup, Extension, find_packages
+# from distutils.core import setup, Extension
 from Cython.Distutils import build_ext
 
 import numpy
@@ -78,7 +79,8 @@ setup(
     url='https://github.com/alberlab/alabtools',
     description='Alber lab toolbox',
     cmdclass=cmdclass,
-    packages=['alabtools'],
+    # packages=['alabtools'],
+    packages=find_packages(),
     package_data={'alabtools': ['genomes/*', 'config/*']},
     install_requires=install_requires,
     # tests_require=tests_require,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from setuptools import setup, Extension, find_packages
-# from distutils.core import setup, Extension
+# from distutils.core import setup, Extension  # old way, replaced by setuptools
 from Cython.Distutils import build_ext
 
 import numpy
@@ -79,7 +79,7 @@ setup(
     url='https://github.com/alberlab/alabtools',
     description='Alber lab toolbox',
     cmdclass=cmdclass,
-    # packages=['alabtools'],
+    # packages=['alabtools'],  # old way, replaced by find_packages()
     packages=find_packages(),
     package_data={'alabtools': ['genomes/*', 'config/*']},
     install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ clscripts = [
 cmdclass.update({'build_ext': build_ext})
 setup(
     name='alabtools',
-    version='1.1.0',
+    version='1.1.0+bugfix_import',
     author='Nan Hua, Francesco Musella',
     author_email='nhua@usc.edu',
     url='https://github.com/alberlab/alabtools',

--- a/test/imaging_test.py
+++ b/test/imaging_test.py
@@ -2,9 +2,9 @@ import unittest
 import os
 import numpy as np
 from alabtools import Genome, Index
-from alabtools import CtFile
+from alabtools.imaging import CtFile
 from alabtools.imaging.utils_imaging import flatten_coordinates
-from alabtools import WSPhaser
+from alabtools.imaging.phasing import WSPhaser
 from alabtools.imaging.ctenvelope import fit_alphashape
 
 
@@ -197,10 +197,6 @@ class TestCtFile(unittest.TestCase):
         # sort the copies
         ct.sort_copies()
         
-        print('Printing coordinates in test_sort_copies')
-        print(coordinates_tosort.shape)
-        print(ct.coordinates.shape)
-
         # check the results
         np.testing.assert_array_almost_equal(ct.coordinates, coordinates_test, decimal=3)
         np.testing.assert_array_equal(ct.nspot, nspot_test)

--- a/test/test_parallels/submit.sh
+++ b/test/test_parallels/submit.sh
@@ -12,8 +12,8 @@
 #$ -l h_rt=96:00:00
 #$ -l highp
 #$ -cwd
-#$ -o out
-#$ -e err
+#$ -o out_submit
+#$ -e err_submit
 #$ -V 
 #$ -pe shared 2
 

--- a/test/test_parallels/test_parallel_ctenv.py
+++ b/test/test_parallels/test_parallel_ctenv.py
@@ -32,7 +32,7 @@ ctenv = CtEnvelope(ctenv_name, 'w')
 
 # define the ctenv configuration for the run
 config = {'ct_name': ct_name,
-          'parallel': {'controller': 'serial'},
+          'parallel': {'controller': 'ipyparallel'},
           'fit parameters': {'alpha': 0.0005,
                              'force': False,
                              'delta_alpha': 0.0001,

--- a/test/test_parallels/test_parallel_ctenv.py
+++ b/test/test_parallels/test_parallel_ctenv.py
@@ -1,36 +1,38 @@
 import numpy as np
 import time
 import os
-from alabtools import CtFile
-from alabtools import CtEnvelope
+from alabtools.imaging import CtFile
+from alabtools.imaging import CtEnvelope
 
-# print working directory
 print('\n')
-print('Current working directory:')
-print(os.getcwd())
-print('\n\n')
 
-# print file directory
-print('\n')
-print('File directory:')
-print(os.path.dirname(os.path.realpath(__file__)))
-print('\n\n')
+# print working directory and file directory
+print('Current working directory:\n{}\n\n'.format(os.getcwd()))
+print('File directory:\n{}\n\n'.format(os.path.dirname(os.path.realpath(__file__))))
+
+# change working directory to file directory
+print('Changing working directory to file directory...\n\n')
+os.chdir(os.path.dirname(os.path.realpath(__file__)))
+
+# print working directory and file directory
+print('Current working directory:\n{}\n\n'.format(os.getcwd()))
+print('File directory:\n{}\n\n'.format(os.path.dirname(os.path.realpath(__file__))))
 
 # load the ct file
-ct_name = 'takei_comb.ct'
+ct_name = 'takei_rep1.ct'
 ct_name = os.path.join(os.path.dirname(os.path.realpath(__file__)), ct_name)
 ct = CtFile(ct_name)
 print(ct.coordinates.shape)
 ct.close()
 
 # create the ctenv file
-ctenv_name = 'takei_comb.ctenv'
+ctenv_name = 'takei_rep1.ctenv'
 ctenv_name = os.path.join(os.path.dirname(os.path.realpath(__file__)), ctenv_name)
 ctenv = CtEnvelope(ctenv_name, 'w')
 
 # define the ctenv configuration for the run
 config = {'ct_name': ct_name,
-          'parallel': {'controller': 'ipyparallel'},
+          'parallel': {'controller': 'serial'},
           'fit parameters': {'alpha': 0.0005,
                              'force': False,
                              'delta_alpha': 0.0001,

--- a/test/test_parallels/test_parallel_phasing.py
+++ b/test/test_parallels/test_parallel_phasing.py
@@ -4,15 +4,28 @@ import os
 from alabtools.imaging.ctfile import CtFile
 from alabtools.imaging.phasing import WSPhaser
 
+print('\n')
 
-ct_name = 'ct_takei_comb.ct'
+# print working directory and file directory
+print('Current working directory:\n{}\n\n'.format(os.getcwd()))
+print('File directory:\n{}\n\n'.format(os.path.dirname(os.path.realpath(__file__))))
+
+# change working directory to file directory
+print('Changing working directory to file directory...\n\n')
+os.chdir(os.path.dirname(os.path.realpath(__file__)))
+
+# print working directory and file directory
+print('Current working directory:\n{}\n\n'.format(os.getcwd()))
+print('File directory:\n{}\n\n'.format(os.path.dirname(os.path.realpath(__file__))))
+
+ct_name = 'takei_rep1.ct'
 ct_name = os.path.join(os.getcwd(), ct_name)
 ct = CtFile(ct_name)  # load the ct file
 print(ct.coordinates.shape)
 ct.close()
 
 config = {'ct_name': ct_name,
-          'parallel': {'controller': 'ipyparallel'},
+          'parallel': {'controller': 'serial'},
           'ncluster': {'#': 2, 'chrX': 1},
           'additional_parameters': {'st': 1.2, 'ot': 2.5}}
 phaser = WSPhaser(config)


### PR DESCRIPTION
Package import in setup.py was not allowing for python sub-packages within alabtools (i.e. imaging, which is the only one for now). Fixed by using the setuptools module, with its find_packages function.