### PR TITLE
Bugfix Genome <- chroms Order

### DIFF
--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -206,6 +206,8 @@ class Contactmatrix(object):
         self._build_index(self.resolution)
 
         origenome = utils.Genome(assembly, usechr=['#', 'X', 'Y'], silence=True)
+        # ATTENTION: chromosomes in origenome must be sorted for this code to work
+        # (i.e. 'chr1', 'chr2', ... NOT 'chr1', 'chr10', 'chr11', ...)
         allChrId = [origenome.getchrnum(self.genome[x]) for x in range(len(self.genome))]
         chrIdRange = [[allChrId[0], allChrId[0] + 1]]
         for i in allChrId[1:]:

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -207,7 +207,7 @@ class Contactmatrix(object):
 
         origenome = utils.Genome(assembly, usechr=['#', 'X', 'Y'], silence=True)
         # ATTENTION: chromosomes in origenome must be sorted for this code to work
-        # (i.e. 'chr1', 'chr2', ... NOT 'chr1', 'chr10', 'chr11', ...)
+        # (i.e. 'chr1', 'chr2', ... NOT 'chr1', 'chr10', 'chr11', ..., 'chr2', ...)
         allChrId = [origenome.getchrnum(self.genome[x]) for x in range(len(self.genome))]
         chrIdRange = [[allChrId[0], allChrId[0] + 1]]
         for i in allChrId[1:]:

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -208,7 +208,6 @@ class Contactmatrix(object):
         origenome = utils.Genome(assembly, usechr=['#', 'X', 'Y'], silence=True)
         # ATTENTION: chromosomes in origenome must be sorted for this code to work
         # (i.e. 'chr1', 'chr2', ... NOT 'chr1', 'chr10', 'chr11', ...)
-        print([x for x in range(len(self.genome))])
         allChrId = [origenome.getchrnum(self.genome[x]) for x in range(len(self.genome))]
         chrIdRange = [[allChrId[0], allChrId[0] + 1]]
         for i in allChrId[1:]:

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -208,6 +208,7 @@ class Contactmatrix(object):
         origenome = utils.Genome(assembly, usechr=['#', 'X', 'Y'], silence=True)
         # ATTENTION: chromosomes in origenome must be sorted for this code to work
         # (i.e. 'chr1', 'chr2', ... NOT 'chr1', 'chr10', 'chr11', ...)
+        print([x for x in range(len(self.genome))])
         allChrId = [origenome.getchrnum(self.genome[x]) for x in range(len(self.genome))]
         chrIdRange = [[allChrId[0], allChrId[0] + 1]]
         for i in allChrId[1:]:

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -185,7 +185,6 @@ class Genome(object):
 
     # -
 
-    # Write a private static method to convert the list of chromosomes to the appropriate format
     @staticmethod
     def _convert_chroms(chroms):
         # Case 1: chroms is a list of binary strings

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -164,6 +164,7 @@ class Genome(object):
         # Convert chroms to appropriate format and sort them
         chroms = self._standardize_chromosomes(chroms)
         chroms = self._sort_chromosomes(chroms)
+        chroms = np.array(chroms, dtype=CHROMS_DTYPE)
 
         choices = np.zeros(len(chroms), dtype=bool)
 
@@ -228,25 +229,24 @@ class Genome(object):
         
         # Loop through chromosomes and convert to numbers for sorting
         for chrom in chroms:
-            chrombase = chrom.split('chr')[1]
+            chrombase = chrom.split('chr')[1]  # remove 'chr' prefix
             if chrombase.isdigit():  # if it's a number
                 chromnums.append(int(chrombase))
+            # The chromosome number of X, Y, M, ..., changes depending
+            # on the genome assembly. Here we assign them to 100, 101, 102, ...
+            # so that we are sure that they come after the autosomes
             elif chrombase == 'X':
-                # if it's mouse this should be 20, but it doesn't matter
-                chromnums.append(23)
+                chromnums.append(100)
             elif chrombase == 'Y':
-                chromnums.append(24)
+                chromnums.append(101)
             elif chrombase == 'M':
-                chromnums.append(25)
+                chromnums.append(102)
+            # This is to deal with other chr labels (e.g. 'chr1_random')
             else:
-                # This is to deal with other chr labels (e.g. 'chr1_random')
-                chromnums.append(26)
+                chromnums.append(103)
                 
         # Sort chroms by chromnums
         chroms = [chrom for (chromnum, chrom) in sorted(zip(chromnums, chroms))]
-        
-        # Convert chroms to numpy array of CHROMS_DTYPE
-        chroms = np.array(chroms, dtype=CHROMS_DTYPE)
         
         return chroms
     

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -160,6 +160,9 @@ class Genome(object):
             chroms = np.array(chroms, dtype=CHROMS_DTYPE)
             lengths = np.array(lengths, dtype=LENGTHS_DTYPE)
             origins = np.array(origins, dtype=ORIGINS_DTYPE)
+        
+        # Change chroms to the appropriate format
+        chroms = self._convert_chroms(chroms)
 
         choices = np.zeros(len(chroms), dtype=bool)
 
@@ -174,6 +177,7 @@ class Genome(object):
                 # if specified with full name, remove chr
                 chrnum = chrnum.replace('chr', '')
                 choices = np.logical_or(chroms == ("chr%s" % chrnum), choices)
+        
         self.chroms = chroms[choices]  # convert to unicode for python2/3 compatibility
         self.origins = origins[choices]
         self.lengths = lengths[choices]
@@ -181,6 +185,20 @@ class Genome(object):
 
     # -
 
+    # Write a private static method to convert the list of chromosomes to the appropriate format
+    @staticmethod
+    def _convert_chroms(chroms):
+        # Case 1: chroms is a list of binary strings
+        if isinstance(chroms[0], bytes):
+            chroms = [x.decode('utf-8') for x in chroms]
+        # If the chromosomes don't start with chr, add it
+        for i in range(len(chroms)):
+            if chroms[i][0:3] != 'chr':
+                chroms[i] = 'chr' + chroms[i]
+        # Convert chroms to numpy array of CHROMS_DTYPE
+        chroms = np.array(chroms, dtype=CHROMS_DTYPE)
+        return chroms
+    
     def __eq__(self, other):
         try:
             return (

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ clscripts = [
 cmdclass.update({'build_ext': build_ext})
 setup(
     name='alabtools',
-    version='1.1.0+bugfix',
+    version='1.1.1',
     author='Nan Hua, Francesco Musella',
     author_email='nhua@usc.edu',
     url='https://github.com/alberlab/alabtools',

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ clscripts = [
 cmdclass.update({'build_ext': build_ext})
 setup(
     name='alabtools',
-    version='1.1.0',
+    version='1.1.0+bugfix',
     author='Nan Hua, Francesco Musella',
     author_email='nhua@usc.edu',
     url='https://github.com/alberlab/alabtools',


### PR DESCRIPTION
Fixed a bug when processing a cool file with chromosome named '1', '2', ... (in binary format) instead of 'chr1', 'chr2', ...

Solved by introducing a conversion method that changes the chromosomes in the appropriate format and a sorting method. These methods are called in init.py of Genome.