### PR TITLE
Bugfix_hcs_buildgenome

### DIFF
--- a/alabtools/__init__.py
+++ b/alabtools/__init__.py
@@ -8,7 +8,7 @@ This is the new build of lab tools
 """
 
 from .api import Contactmatrix
-from .utils import Genome, Index
+from .utils import Genome, Index, standardize_chromosomes
 from .analysis import HssFile
 from . import plots, analysis
 

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -116,7 +116,7 @@ class Contactmatrix(object):
                 # self._load_cool(h5, assembly=genome, usechr=usechr)
                 # h5.close()
                 cool = cooler.Cooler(mat)
-                self._load_cool_new(cool, assembly=genome, usechr=usechr)
+                self.load_cool_new(cool, assembly=genome, usechr=usechr)
                 cool.close()
             elif os.path.splitext(mat)[1] == '.mcool':
                 h5 = h5py.File(mat)
@@ -307,7 +307,7 @@ class Contactmatrix(object):
 
         return attr
 
-    def _load_cool_new(self, cool, assembly=None, usechr=('#', 'X', 'Y')):
+    def load_cool_new(self, cool, assembly=None, usechr=('#', 'X', 'Y')):
         
         # Read the assembly
         if assembly is None:

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -117,7 +117,6 @@ class Contactmatrix(object):
                 # h5.close()
                 cool = cooler.Cooler(mat)
                 self.load_cool_new(cool, assembly=genome, usechr=usechr)
-                cool.close()
             elif os.path.splitext(mat)[1] == '.mcool':
                 h5 = h5py.File(mat)
                 print("Loading matrix from mcool, resolution={}".format(resolution))

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -327,8 +327,9 @@ class Contactmatrix(object):
         # Build the matrix
         # Get the complete contact matrix of the cooler file
         mat = cool.matrix(balance=False)[:]
-        # Get the complete domain BED of the cooler file
-        chromstr, start, end  = cool.bins()[:]
+        # Get the complete chromstr from the domain BED of the cooler file
+        chromstr  = cool.bins()[:]['chrom']
+        chromstr = np.array(list(chromstr))
         # Standardize chromstr (e.g.'1' -> 'chr1')
         chromstr = utils.standardize_chromosomes(chromstr)
         chromstr = np.array(chromstr)
@@ -339,8 +340,8 @@ class Contactmatrix(object):
                 mask[chromstr == chrom] = False
         # Apply the mask
         mat = mat[mask, :][:, mask]
-
-        return None
+        # Store the sparse matrix
+        self.matrix = matrix.sss_matrix(mat)
 
     def _load_pairs_bgzip(self, filename, resolution, usechr=('#', 'X')):
         import pypairix

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -324,15 +324,21 @@ class Contactmatrix(object):
         # Build the index
         self._build_index(self.resolution)
         
-        # Get the complete domain BED of the cooler file
-        chroms, start, end  = cool.bins()[:]
-        
+        # Build the matrix
         # Get the complete contact matrix of the cooler file
         mat = cool.matrix(balance=False)[:]
-
-        # remove 'chrM' from chroms and mat
-        chroms = chroms[chroms != 'chrM']
-        mat = mat[chroms != 'chrM', :][:, chroms != 'chrM']
+        # Get the complete domain BED of the cooler file
+        chromstr, start, end  = cool.bins()[:]
+        # Standardize chromstr (e.g.'1' -> 'chr1')
+        chromstr = utils.standardize_chromosomes(chromstr)
+        chromstr = np.array(chromstr)
+        # Create a mask to remove chromosomes not present in self.genome
+        mask = np.ones(len(chromstr), dtype=bool)
+        for chrom in np.unique(chromstr):
+            if chrom not in self.genome:
+                mask[chromstr == chrom] = False
+        # Apply the mask
+        mat = mat[mask, :][:, mask]
 
         return None
 

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -924,6 +924,7 @@ class Contactmatrix(object):
                                 lengths=self.genome.lengths)
 
         if isinstance(step, string_types):
+            # Reads a BED file with domains
             tadDef = np.genfromtxt(step, dtype=None, encoding=None)
 
             chrom = tadDef['f0']
@@ -956,6 +957,8 @@ class Contactmatrix(object):
                                   )
             newMatrix._set_index(chrom, start, end, label)
         else:
+            # Case we enter if step is not a string
+            # We enter here if step is a number (int)
             newMatrix._build_index(self.resolution * step)
 
         DimB = len(newMatrix.index)
@@ -987,7 +990,10 @@ class Contactmatrix(object):
                                   mapping,
                                   Bi, Bj, Bx)
         newMatrix.matrix = matrix.sss_matrix((Bx, (Bi, Bj)))
-        newMatrix.resolution = -1
+        if isinstance(step, int):
+            newMatrix.resolution = self.resolution * step
+        else:  # resolution can't be defined
+            newMatrix.resolution = -1
         return newMatrix
 
     def fmaxScaling(self, fmax, force=False):

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -206,6 +206,8 @@ class Contactmatrix(object):
         self._build_index(self.resolution)
 
         origenome = utils.Genome(assembly, usechr=['#', 'X', 'Y'], silence=True)
+        # ATTENTION: chromosomes in origenome must be sorted for this code to work
+        # (i.e. 'chr1', 'chr2', ... NOT 'chr1', 'chr10', 'chr11', ...)
         allChrId = [origenome.getchrnum(self.genome[x]) for x in range(len(self.genome))]
         chrIdRange = [[allChrId[0], allChrId[0] + 1]]
         for i in allChrId[1:]:

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -398,7 +398,7 @@ class Contactmatrix(object):
         
         # Get the original chromint from the index
         chromint_old = self.index.get_chromint()
-        
+
         # Sort the genome
         self.genome.sort()
         
@@ -406,7 +406,7 @@ class Contactmatrix(object):
         self.index = self.genome.bininfo(self.resolution)
         
         # Sort the matrix
-        order = np.argsort(chromint_old)  # get the order of the chromosomes before sorting
+        order = np.argsort(chromint_old, kind='mergesort')  # get the order of the chromosomes before sorting
         mat = self.matrix.toarray()  # convert to dense matrix
         mat = mat[order, :]
         mat = mat[:, order]

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -307,11 +307,12 @@ class Contactmatrix(object):
         Modifies Genome, Index, and Matrix in place.
         """
         
-        # Get the chromosome order from the genome
-        chrom_order = self.genome._get_chromosome_sorting()
-        
+        # Get the original chromstr from the index
+        chromstr = self.index.chromstr
         # Sort the genome
-        self.genome.sort(chrom_order.values())
+        self.genome.sort()
+        # Get the sorted index
+        self.index = self.genome.bininfo(self.resolution)
     
     def rowsum(self):
         return self.matrix.sum(axis=1)

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -207,7 +207,7 @@ class Contactmatrix(object):
 
         origenome = utils.Genome(assembly, usechr=['#', 'X', 'Y'], silence=True)
         # ATTENTION: chromosomes in origenome must be sorted for this code to work
-        # (i.e. 'chr1', 'chr2', ... NOT 'chr1', 'chr10', 'chr11', ...)
+        # (i.e. 'chr1', 'chr2', ... NOT 'chr1', 'chr10', 'chr11', ..., 'chr2', ...)
         allChrId = [origenome.getchrnum(self.genome[x]) for x in range(len(self.genome))]
         chrIdRange = [[allChrId[0], allChrId[0] + 1]]
         for i in allChrId[1:]:

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -205,25 +205,9 @@ class Contactmatrix(object):
         self._build_genome(assembly, usechr=usechr, chroms=h5['chroms']['name'][:], lengths=h5['chroms']['length'][:])
         self._build_index(self.resolution)
 
-        # I think that origenome is needed if - in the usechr passed to _load_cool,
-        # we don't include all chromosomes present in the cool file.
-        # In that case, we would be looping over a smaller sample of chromosomes than
-        # the actual cool file, and this would mess up the association between chr and chrID.
-        # (note: chrID is not actually the ID, but rather the position of chr in the list).
-        
-        # However, I don't think that reading the genome from the assembly file makes sense:
-        #   1) the chromosomes in the cool file might not match the ones in the assembly file
-        #   2) the order of the chromosomes in the cool file might not match the one in the assembly file
-        
-        # So I think we have to substitute the line (commented below):
-        # origenome = utils.Genome(assembly, usechr=['#', 'X', 'Y'], silence=True)
-        # with
-        origenome = utils.Genome(assembly, chroms=h5['chroms']['name'][:], origins=None,
-                                 lengths=h5['chroms']['length'][:], usechr=['#', 'X', 'Y'])
-        # in this way we are sure we're including the chromosomes of the cool file in the right order.
-        # The only issue is that the list ['#', 'X', 'Y'] might not include every chromosome,
-        # if special ones (e.g. chrM) are present in the cool file.
-        
+        origenome = utils.Genome(assembly, usechr=['#', 'X', 'Y'], silence=True)
+        # ATTENTION: chromosomes in origenome must be sorted for this code to work
+        # (i.e. 'chr1', 'chr2', ... NOT 'chr1', 'chr10', 'chr11', ..., 'chr2', ...)
         allChrId = [origenome.getchrnum(self.genome[x]) for x in range(len(self.genome))]
         chrIdRange = [[allChrId[0], allChrId[0] + 1]]
         for i in allChrId[1:]:

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -205,9 +205,25 @@ class Contactmatrix(object):
         self._build_genome(assembly, usechr=usechr, chroms=h5['chroms']['name'][:], lengths=h5['chroms']['length'][:])
         self._build_index(self.resolution)
 
-        origenome = utils.Genome(assembly, usechr=['#', 'X', 'Y'], silence=True)
-        # ATTENTION: chromosomes in origenome must be sorted for this code to work
-        # (i.e. 'chr1', 'chr2', ... NOT 'chr1', 'chr10', 'chr11', ..., 'chr2', ...)
+        # I think that origenome is needed if - in the usechr passed to _load_cool,
+        # we don't include all chromosomes present in the cool file.
+        # In that case, we would be looping over a smaller sample of chromosomes than
+        # the actual cool file, and this would mess up the association between chr and chrID.
+        # (note: chrID is not actually the ID, but rather the position of chr in the list).
+        
+        # However, I don't think that reading the genome from the assembly file makes sense:
+        #   1) the chromosomes in the cool file might not match the ones in the assembly file
+        #   2) the order of the chromosomes in the cool file might not match the one in the assembly file
+        
+        # So I think we have to substitute the line (commented below):
+        # origenome = utils.Genome(assembly, usechr=['#', 'X', 'Y'], silence=True)
+        # with
+        origenome = utils.Genome(assembly, chroms=h5['chroms']['name'][:], origins=None,
+                                 lengths=h5['chroms']['length'][:], usechr=['#', 'X', 'Y'])
+        # in this way we are sure we're including the chromosomes of the cool file in the right order.
+        # The only issue is that the list ['#', 'X', 'Y'] might not include every chromosome,
+        # if special ones (e.g. chrM) are present in the cool file.
+        
         allChrId = [origenome.getchrnum(self.genome[x]) for x in range(len(self.genome))]
         chrIdRange = [[allChrId[0], allChrId[0] + 1]]
         for i in allChrId[1:]:

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -307,12 +307,21 @@ class Contactmatrix(object):
         Modifies Genome, Index, and Matrix in place.
         """
         
-        # Get the original chromstr from the index
-        chromstr = self.index.chromstr
+        # Get the original chromint from the index
+        chromint_old = self.index.get_chromint()
+        
         # Sort the genome
         self.genome.sort()
+        
         # Get the sorted index
         self.index = self.genome.bininfo(self.resolution)
+        
+        # Sort the matrix
+        order = np.argsort(chromint_old)  # get the order of the chromosomes before sorting
+        mat = self.matrix.toarray()  # convert to dense matrix
+        mat = mat[order, :]
+        mat = mat[:, order]
+        self.matrix = matrix.sss_matrix(mat)
     
     def rowsum(self):
         return self.matrix.sum(axis=1)

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -205,7 +205,14 @@ class Contactmatrix(object):
         self._build_genome(assembly, usechr=usechr, chroms=h5['chroms']['name'][:], lengths=h5['chroms']['length'][:])
         self._build_index(self.resolution)
 
-        origenome = utils.Genome(assembly, usechr=['#', 'X', 'Y'], silence=True)
+        # this doesn't work right now because origenome and self.genome have different order
+        # maybe we can use
+        # origenome = utils.Genome(assembly, h5['chroms']['name'][:],
+        #                          lengths=h5['chroms']['length'][:], usechr=["#", "X", "Y"])?
+        
+        # origenome = utils.Genome(assembly, usechr=['#', 'X', 'Y'], silence=True)
+        origenome = utils.Genome(assembly, h5['chroms']['name'][:],
+                                 lengths=h5['chroms']['length'][:], usechr=["#", "X", "Y"])
         allChrId = [origenome.getchrnum(self.genome[x]) for x in range(len(self.genome))]
         chrIdRange = [[allChrId[0], allChrId[0] + 1]]
         for i in allChrId[1:]:

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -206,8 +206,6 @@ class Contactmatrix(object):
         self._build_index(self.resolution)
 
         origenome = utils.Genome(assembly, usechr=['#', 'X', 'Y'], silence=True)
-        # ATTENTION: chromosomes in origenome must be sorted for this code to work
-        # (i.e. 'chr1', 'chr2', ... NOT 'chr1', 'chr10', 'chr11', ..., 'chr2', ...)
         allChrId = [origenome.getchrnum(self.genome[x]) for x in range(len(self.genome))]
         chrIdRange = [[allChrId[0], allChrId[0] + 1]]
         for i in allChrId[1:]:
@@ -303,6 +301,18 @@ class Contactmatrix(object):
         self.matrix = matrix.sss_matrix((data, indices, indptr), shape=(len(self.index), len(self.index)))
 
     # -------------------
+     
+    def sort(self):
+        """Sorts the HCS file by chromosome.
+        Modifies Genome, Index, and Matrix in place.
+        """
+        
+        # Get the chromosome order from the genome
+        chrom_order = self.genome._get_chromosome_sorting()
+        
+        # Sort the genome
+        self.genome.sort(chrom_order.values())
+    
     def rowsum(self):
         return self.matrix.sum(axis=1)
 

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -275,7 +275,8 @@ class Contactmatrix(object):
         
         # Build the matrix
         # Get the complete contact matrix of the cooler file
-        mat = cool.matrix(balance=False)[:]
+        mat = cool.matrix(balance=False, sparse=True)[:]  # COO matrix
+        mat = mat.tocsr()  # convert to CSR matrix
         # Get the complete chromstr from the domain BED of the cooler file
         chromstr  = cool.bins()[:]['chrom']
         chromstr = np.array(list(chromstr))
@@ -290,7 +291,7 @@ class Contactmatrix(object):
         # Apply the mask
         mat = mat[mask, :][:, mask]
         # Store the sparse matrix
-        self.matrix = matrix.sss_matrix(mat)
+        self.matrix = matrix.sss_matrix(mat, shape=mat.shape)
 
     def _load_pairs_bgzip(self, filename, resolution, usechr=('#', 'X')):
         import pypairix

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -208,7 +208,6 @@ class Contactmatrix(object):
         origenome = utils.Genome(assembly, usechr=['#', 'X', 'Y'], silence=True)
         # ATTENTION: chromosomes in origenome must be sorted for this code to work
         # (i.e. 'chr1', 'chr2', ... NOT 'chr1', 'chr10', 'chr11', ...)
-        print([x for x in range(len(self.genome))])
         allChrId = [origenome.getchrnum(self.genome[x]) for x in range(len(self.genome))]
         chrIdRange = [[allChrId[0], allChrId[0] + 1]]
         for i in allChrId[1:]:

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -112,18 +112,12 @@ class Contactmatrix(object):
             elif os.path.splitext(mat)[1] == '.hcs':
                 self._load_hcs(mat, lazy=lazy)
             elif os.path.splitext(mat)[1] == '.cool':
-                # h5 = h5py.File(mat)
-                # self._load_cool(h5, assembly=genome, usechr=usechr)
-                # h5.close()
                 cool = cooler.Cooler(mat)
                 self.load_cool(cool, assembly=genome, usechr=usechr)
             elif os.path.splitext(mat)[1] == '.mcool':
-                # h5 = h5py.File(mat)
                 print("Loading matrix from mcool, resolution={}".format(resolution))
                 cool = cooler.Cooler('{}::resolutions/{}'.format(mat, resolution))
                 self.load_cool(cool, assembly=genome, usechr=usechr)
-                # self._load_cool(h5['resolutions']['{}'.format(resolution)], assembly=genome, usechr=usechr)
-                # h5.close()
             elif os.path.splitext(mat)[1] == '.hic':
                 self._load_hic(mat, resolution=resolution, usechr=usechr)
             elif os.path.splitext(mat)[1] == '.gz' and os.path.splitext(os.path.splitext(mat)[0])[1] == '.pairs':

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -208,6 +208,7 @@ class Contactmatrix(object):
         origenome = utils.Genome(assembly, usechr=['#', 'X', 'Y'], silence=True)
         # ATTENTION: chromosomes in origenome must be sorted for this code to work
         # (i.e. 'chr1', 'chr2', ... NOT 'chr1', 'chr10', 'chr11', ...)
+        print([x for x in range(len(self.genome))])
         allChrId = [origenome.getchrnum(self.genome[x]) for x in range(len(self.genome))]
         chrIdRange = [[allChrId[0], allChrId[0] + 1]]
         for i in allChrId[1:]:

--- a/alabtools/api.py
+++ b/alabtools/api.py
@@ -323,6 +323,16 @@ class Contactmatrix(object):
         
         # Build the index
         self._build_index(self.resolution)
+        
+        # Get the complete domain BED of the cooler file
+        chroms, start, end  = cool.bins()[:]
+        
+        # Get the complete contact matrix of the cooler file
+        mat = cool.matrix(balance=False)[:]
+
+        # remove 'chrM' from chroms and mat
+        chroms = chroms[chroms != 'chrM']
+        mat = mat[chroms != 'chrM', :][:, chroms != 'chrM']
 
         return None
 

--- a/alabtools/matrix.py
+++ b/alabtools/matrix.py
@@ -90,6 +90,7 @@ class sss_matrix(object):
             self.diagonal = arg1['diag']
 
         else:
+            # Case used in Contactmatrix / load_cool
             self.csr = triu(csr_matrix(arg1, shape=shape, dtype=dtype, copy=copy), format='csr')
             self._pop_diag()
             # -

--- a/alabtools/matrix.py
+++ b/alabtools/matrix.py
@@ -63,7 +63,7 @@ class sss_matrix(object):
             self.csr = csr_matrix(np.triu(arg1), shape, dtype, copy)
             self._pop_diag()
 
-        if isinstance(arg1, str):
+        elif isinstance(arg1, str):
             h5 = h5py.File(arg1, 'r')
             self._load_from_h5(h5[h5group], lazy)
 

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -113,7 +113,7 @@ class Genome(object):
     """
 
     def __init__(self, assembly, chroms=None, origins=None, lengths=None,
-                 usechr=None, silence=False):
+                 usechr=None, silence=False, sort_chroms=True):
 
         # If the first argument is a string, and no other info is specified,
         # check if we can read from info or hdf5.
@@ -165,10 +165,11 @@ class Genome(object):
         chroms = self._standardize_chromosomes(chroms)
         
         # Sort chroms, origins, lengths by chromosome name
-        # chromnums = self._sort_by_chromosomes(chroms)
-        # chroms = [chrom for (chromnum, chrom) in sorted(zip(chromnums, chroms))]
-        # lengths = [length for (chromnum, length) in sorted(zip(chromnums, lengths))]
-        # origins = [origin for (chromnum, origin) in sorted(zip(chromnums, origins))]
+        if sort_chroms:
+            chromnums = self._sort_by_chromosomes(chroms)
+            chroms = [chrom for (chromnum, chrom) in sorted(zip(chromnums, chroms))]
+            lengths = [length for (chromnum, length) in sorted(zip(chromnums, lengths))]
+            origins = [origin for (chromnum, origin) in sorted(zip(chromnums, origins))]
         
         # Convert to numpy arrays
         chroms = np.array(chroms, dtype=CHROMS_DTYPE)

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -244,25 +244,32 @@ class Genome(object):
         """
         
         # Initialize list of chromosome numbers
-        chromorders = {}
+        chromorders = []
         
         # Loop through chromosomes and convert to numbers for sorting
         for chrom in self.chroms:
             chrombase = chrom.split('chr')[1]  # remove 'chr' prefix
             if chrombase.isdigit():  # if it's a number
-                chromorders[chrom] = int(chrombase)
+                chromorders.append(int(chrombase))
             # The chromosome number of X, Y, M, ..., changes depending
             # on the genome assembly. Here we assign them to 100, 101, 102, ...
             # so that we are sure that they come after the autosomes
             elif chrombase == 'X':
-                chromorders[chrom] = 100
+                chromorders.append(100)
             elif chrombase == 'Y':
-                chromorders[chrom] = 101
+                chromorders.append(101)
             elif chrombase == 'M':
-                chromorders[chrom] = 102
+                chromorders.append(102)
             # This is to deal with other chr labels (e.g. 'chr1_random')
             else:
-                chromorders[chrom] = 103 + len(chromorders)
+                chromorders.append(103 + len(chromorders))
+        
+        # converts chromorders to a rank array,
+        # e.g. [4, 2, 7, 1, 100] -> [2, 1, 3, 0, 4]
+        chromorders = np.argsort(np.argsort(chromorders))
+        
+        # Convert to a dict
+        chromorders = dict(zip(self.chroms, chromorders))
         
         return chromorders
     

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -161,10 +161,19 @@ class Genome(object):
             lengths = np.array(lengths, dtype=LENGTHS_DTYPE)
             origins = np.array(origins, dtype=ORIGINS_DTYPE)
         
-        # Convert chroms to appropriate format and sort them
+        # Convert chroms to appropriate format
         chroms = self._standardize_chromosomes(chroms)
-        chroms = self._sort_chromosomes(chroms)
+        
+        # Sort chroms, origins, lengths by chromosome name
+        chromnums = self._sort_by_chromosomes(chroms)
+        chroms = [chrom for (chromnum, chrom) in sorted(zip(chromnums, chroms))]
+        lengths = [length for (chromnum, length) in sorted(zip(chromnums, lengths))]
+        origins = [origin for (chromnum, origin) in sorted(zip(chromnums, origins))]
+        
+        # Convert to numpy arrays
         chroms = np.array(chroms, dtype=CHROMS_DTYPE)
+        lengths = np.array(lengths, dtype=LENGTHS_DTYPE)
+        origins = np.array(origins, dtype=ORIGINS_DTYPE)
 
         choices = np.zeros(len(chroms), dtype=bool)
 
@@ -214,14 +223,14 @@ class Genome(object):
         return chroms
     
     @staticmethod
-    def _sort_chromosomes(chroms):
-        """Sort chromosomes by chromosome number.
+    def _sort_by_chromosomes(chroms):
+        """Get the order of chromosomes as a list of indices.
 
         Args:
             chroms (list): A list of chromosome identifiers (strings).
 
         Returns:
-            np.array: A sorted numpy array of chromosomes with dtype CHROMS_DTYPE.
+            list: A list of indices that sorts the chromosomes.
         """
         
         # Initialize list of chromosome numbers
@@ -244,11 +253,8 @@ class Genome(object):
             # This is to deal with other chr labels (e.g. 'chr1_random')
             else:
                 chromnums.append(103)
-                
-        # Sort chroms by chromnums
-        chroms = [chrom for (chromnum, chrom) in sorted(zip(chromnums, chroms))]
         
-        return chroms
+        return chromnums
     
     def __eq__(self, other):
         try:

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -240,7 +240,7 @@ class Genome(object):
             chroms (list): A list of chromosome identifiers (strings).
 
         Returns:
-            dict: A dict that maps chromosome identifiers to their order.
+            np.array: A list of indices that sorts the chromosomes.
         """
         
         # Initialize list of chromosome numbers
@@ -268,22 +268,14 @@ class Genome(object):
         # e.g. [4, 2, 7, 1, 100] -> [2, 1, 3, 0, 4]
         chromorders = np.argsort(np.argsort(chromorders))
         
-        # Convert to a dict
-        chromorders = dict(zip(self.chroms, chromorders))
-        
         return chromorders
     
-    def sort(self, order):
+    def sort(self):
         """Sort the genome by the input order.
         Modify the genome (chroms, lenghts, origins) in place.
-
-        Args:
-            order (list): List with the new order.
-
-        Returns:
-            None
         """
         
+        order = self.get_chromosome_sorting()
         self.chroms = [chrom for (_, chrom) in sorted(zip(order, self.chroms))]
         self.lengths = [length for (_, length) in sorted(zip(order, self.lengths))]
         self.origins = [origin for (_, origin) in sorted(zip(order, self.origins))]
@@ -672,23 +664,6 @@ class Index(object):
             np.concatenate([self.label, other.label]),
             genome=self.genome
         )
-    
-    def sort_by_chroms(order_chroms):
-        """Sorts the index by a given order of chromosomes.
-        Modify the index in place.
-
-        Args:
-            order_chroms (dict): Dictionary with the order of the chromosomes.
-        """
-        
-        # Use the order_chroms dict to sort
-        
-        # for instance, we can do something like
-        # chroms_sort = []
-        # for chrom in order_chroms:
-        #    chroms_sort.append(self.chromstr[self.chrom == chrom])
-        
-        return None
 
     def resolution(self):
         '''

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -222,40 +222,6 @@ class Genome(object):
 
         return chroms
     
-    @staticmethod
-    def _sort_by_chromosomes(chroms):
-        """Get the order of chromosomes as a list of indices.
-
-        Args:
-            chroms (list): A list of chromosome identifiers (strings).
-
-        Returns:
-            list: A list of indices that sorts the chromosomes.
-        """
-        
-        # Initialize list of chromosome numbers
-        chromnums = []
-        
-        # Loop through chromosomes and convert to numbers for sorting
-        for chrom in chroms:
-            chrombase = chrom.split('chr')[1]  # remove 'chr' prefix
-            if chrombase.isdigit():  # if it's a number
-                chromnums.append(int(chrombase))
-            # The chromosome number of X, Y, M, ..., changes depending
-            # on the genome assembly. Here we assign them to 100, 101, 102, ...
-            # so that we are sure that they come after the autosomes
-            elif chrombase == 'X':
-                chromnums.append(100)
-            elif chrombase == 'Y':
-                chromnums.append(101)
-            elif chrombase == 'M':
-                chromnums.append(102)
-            # This is to deal with other chr labels (e.g. 'chr1_random')
-            else:
-                chromnums.append(103)
-        
-        return chromnums
-    
     def __eq__(self, other):
         try:
             return (
@@ -266,6 +232,54 @@ class Genome(object):
             )
         except:
             return False
+    
+    def get_chromosome_sorting(self):
+        """Get the order of chromosomes as a list of indices.
+
+        Args:
+            chroms (list): A list of chromosome identifiers (strings).
+
+        Returns:
+            dict: A dict that maps chromosome identifiers to their order.
+        """
+        
+        # Initialize list of chromosome numbers
+        chromorders = {}
+        
+        # Loop through chromosomes and convert to numbers for sorting
+        for chrom in self.chroms:
+            chrombase = chrom.split('chr')[1]  # remove 'chr' prefix
+            if chrombase.isdigit():  # if it's a number
+                chromorders[chrom] = int(chrombase)
+            # The chromosome number of X, Y, M, ..., changes depending
+            # on the genome assembly. Here we assign them to 100, 101, 102, ...
+            # so that we are sure that they come after the autosomes
+            elif chrombase == 'X':
+                chromorders[chrom] = 100
+            elif chrombase == 'Y':
+                chromorders[chrom] = 101
+            elif chrombase == 'M':
+                chromorders[chrom] = 102
+            # This is to deal with other chr labels (e.g. 'chr1_random')
+            else:
+                chromorders[chrom] = 103 + len(chromorders)
+        
+        return chromorders
+    
+    def sort(self, order):
+        """Sort the genome by the input order.
+        Modify the genome (chroms, lenghts, origins) in place.
+
+        Args:
+            order (list): List with the new order.
+
+        Returns:
+            None
+        """
+        
+        self.chroms = [chrom for (_, chrom) in sorted(zip(order, self.chroms))]
+        self.lengths = [length for (_, length) in sorted(zip(order, self.lengths))]
+        self.origins = [origin for (_, origin) in sorted(zip(order, self.origins))]
 
     def bininfo(self, resolution):
 

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -238,6 +238,24 @@ class Genome(object):
         
         return chromorders
     
+    def check_sorted(self):
+        """Check if the genome is sorted by chromosome.
+        A genome is sorted if the chromosomes are in the order
+        chr1, chr2, ..., chrX, chrY, chrM, ...
+        
+        Returns:
+            bool: True if sorted, False otherwise.
+        """
+            
+        # Get the order of chromosomes
+        order = self.get_chromosome_sorting()
+        
+        # Check if the order is the same as the original order
+        if np.all(order == np.arange(len(order))):
+            return True
+        else:
+            return False
+    
     def sort(self):
         """Sort the genome by the input order.
         Modify the genome (chroms, lenghts, origins) in place.
@@ -304,7 +322,7 @@ class Genome(object):
             represent += (self.chroms[i].astype(str) + '\t' + str(self.origins[i]) + '-' + str(
                 self.origins[i] + self.lengths[i]) + '\n')
         return represent
-
+    
     def save(self, h5f, compression="gzip", compression_opts=6):
 
         """

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -165,10 +165,10 @@ class Genome(object):
         chroms = self._standardize_chromosomes(chroms)
         
         # Sort chroms, origins, lengths by chromosome name
-        chromnums = self._sort_by_chromosomes(chroms)
-        chroms = [chrom for (chromnum, chrom) in sorted(zip(chromnums, chroms))]
-        lengths = [length for (chromnum, length) in sorted(zip(chromnums, lengths))]
-        origins = [origin for (chromnum, origin) in sorted(zip(chromnums, origins))]
+        # chromnums = self._sort_by_chromosomes(chroms)
+        # chroms = [chrom for (chromnum, chrom) in sorted(zip(chromnums, chroms))]
+        # lengths = [length for (chromnum, length) in sorted(zip(chromnums, lengths))]
+        # origins = [origin for (chromnum, origin) in sorted(zip(chromnums, origins))]
         
         # Convert to numpy arrays
         chroms = np.array(chroms, dtype=CHROMS_DTYPE)

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -113,7 +113,7 @@ class Genome(object):
     """
 
     def __init__(self, assembly, chroms=None, origins=None, lengths=None,
-                 usechr=None, silence=False, sort_chroms=True):
+                 usechr=None, silence=False):
 
         # If the first argument is a string, and no other info is specified,
         # check if we can read from info or hdf5.
@@ -165,11 +165,10 @@ class Genome(object):
         chroms = self._standardize_chromosomes(chroms)
         
         # Sort chroms, origins, lengths by chromosome name
-        if sort_chroms:
-            chromnums = self._sort_by_chromosomes(chroms)
-            chroms = [chrom for (chromnum, chrom) in sorted(zip(chromnums, chroms))]
-            lengths = [length for (chromnum, length) in sorted(zip(chromnums, lengths))]
-            origins = [origin for (chromnum, origin) in sorted(zip(chromnums, origins))]
+        # chromnums = self._sort_by_chromosomes(chroms)
+        # chroms = [chrom for (chromnum, chrom) in sorted(zip(chromnums, chroms))]
+        # lengths = [length for (chromnum, length) in sorted(zip(chromnums, lengths))]
+        # origins = [origin for (chromnum, origin) in sorted(zip(chromnums, origins))]
         
         # Convert to numpy arrays
         chroms = np.array(chroms, dtype=CHROMS_DTYPE)

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -589,7 +589,10 @@ class Index(object):
                 #       e.g. [0, 0, 0, 1, 1, 2]
                 # self.genome.chroms[self.chrom] is a np.array of strings,
                 #       e.g. ['chr1', 'chr1', 'chr1', 'chr2', 'chr2', 'chr3']
-                self.chromstr = self.genome.chroms[self.chrom]
+                # self.chromstr = self.genome.chroms[self.chrom]
+                self.chromstr = np.ones(len(self.chrom), dtype='U10')
+                for c in np.unique(self.chrom):
+                    self.chromstr[self.chrom == c] = self.genome.chroms[c]
             else:
                 self.chromstr = np.array(['chr%d' % (i + 1) for i in self.chrom])
 

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -185,7 +185,6 @@ class Genome(object):
 
     # -
 
-    # Write a private static method to convert the list of chromosomes to the appropriate format
     @staticmethod
     def _convert_chroms(chroms):
         # Case 1: chroms is a list of binary strings

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -164,6 +164,7 @@ class Genome(object):
         # Convert chroms to appropriate format and sort them
         chroms = self._standardize_chromosomes(chroms)
         chroms = self._sort_chromosomes(chroms)
+        chroms = np.array(chroms, dtype=CHROMS_DTYPE)
 
         choices = np.zeros(len(chroms), dtype=bool)
 
@@ -228,25 +229,24 @@ class Genome(object):
         
         # Loop through chromosomes and convert to numbers for sorting
         for chrom in chroms:
-            chrombase = chrom.split('chr')[1]
+            chrombase = chrom.split('chr')[1]  # remove 'chr' prefix
             if chrombase.isdigit():  # if it's a number
                 chromnums.append(int(chrombase))
+            # The chromosome number of X, Y, M, ..., changes depending
+            # on the genome assembly. Here we assign them to 100, 101, 102, ...
+            # so that we are sure that they come after the autosomes
             elif chrombase == 'X':
-                # if it's mouse this should be 20, but it doesn't matter
-                chromnums.append(23)
+                chromnums.append(100)
             elif chrombase == 'Y':
-                chromnums.append(24)
+                chromnums.append(101)
             elif chrombase == 'M':
-                chromnums.append(25)
+                chromnums.append(102)
+            # This is to deal with other chr labels (e.g. 'chr1_random')
             else:
-                # This is to deal with other chr labels (e.g. 'chr1_random')
-                chromnums.append(26)
+                chromnums.append(103)
                 
         # Sort chroms by chromnums
         chroms = [chrom for (chromnum, chrom) in sorted(zip(chromnums, chroms))]
-        
-        # Convert chroms to numpy array of CHROMS_DTYPE
-        chroms = np.array(chroms, dtype=CHROMS_DTYPE)
         
         return chroms
     

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -739,6 +739,29 @@ class Index(object):
         Returns the unique names of chromosomes in this index
         '''
         return pd.unique(self.chromstr)
+    
+    def get_chromint(self):
+        """Returns the chromosomes in integer format.
+        """
+        # Sort the matrix
+        # convert the chromosome string to an integer (e.g. 'chr1' -> 1)
+        chromint = []
+        for c in self.chromstr:
+            c = c.split('chr')[1]  # remove the 'chr' part
+            if c.isdigit():  # if it's a number
+                c = int(c)
+            elif c == 'X':
+                c = 100  # make X after the autosomes
+            elif c == 'Y':
+                c = 101
+            elif c == 'M':
+                c = 102
+            else:
+                c = 103  # This is to deal with other chr labels (e.g. 'chr1_random')
+            c = int(c)
+            chromint.append(c)
+        chromint = np.array(chromint)
+        return chromint
 
     def __getitem__(self, key):
         return np.rec.fromarrays((self.chrom[key],

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -672,6 +672,23 @@ class Index(object):
             np.concatenate([self.label, other.label]),
             genome=self.genome
         )
+    
+    def sort_by_chroms(order_chroms):
+        """Sorts the index by a given order of chromosomes.
+        Modify the index in place.
+
+        Args:
+            order_chroms (dict): Dictionary with the order of the chromosomes.
+        """
+        
+        # Use the order_chroms dict to sort
+        
+        # for instance, we can do something like
+        # chroms_sort = []
+        # for chrom in order_chroms:
+        #    chroms_sort.append(self.chromstr[self.chrom == chrom])
+        
+        return None
 
     def resolution(self):
         '''

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -578,6 +578,12 @@ class Index(object):
 
         if self.chromstr is None:
             if self.genome is not None:
+                # self.genome.chroms is a np.array strings,
+                #       e.g. ['chr1', 'chr2', 'chr3']
+                # self.chrom is a np.array of integers,
+                #       e.g. [0, 0, 0, 1, 1, 2]
+                # self.genome.chroms[self.chrom] is a np.array of strings,
+                #       e.g. ['chr1', 'chr1', 'chr1', 'chr2', 'chr2', 'chr3']
                 self.chromstr = self.genome.chroms[self.chrom]
             else:
                 self.chromstr = np.array(['chr%d' % (i + 1) for i in self.chrom])

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -164,12 +164,6 @@ class Genome(object):
         # Convert chroms to appropriate format
         chroms = self._standardize_chromosomes(chroms)
         
-        # Sort chroms, origins, lengths by chromosome name
-        # chromnums = self._sort_by_chromosomes(chroms)
-        # chroms = [chrom for (chromnum, chrom) in sorted(zip(chromnums, chroms))]
-        # lengths = [length for (chromnum, length) in sorted(zip(chromnums, lengths))]
-        # origins = [origin for (chromnum, origin) in sorted(zip(chromnums, origins))]
-        
         # Convert to numpy arrays
         chroms = np.array(chroms, dtype=CHROMS_DTYPE)
         lengths = np.array(lengths, dtype=LENGTHS_DTYPE)

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -162,7 +162,7 @@ class Genome(object):
             origins = np.array(origins, dtype=ORIGINS_DTYPE)
         
         # Convert chroms to appropriate format
-        chroms = self._standardize_chromosomes(chroms)
+        chroms = standardize_chromosomes(chroms)
         
         # Convert to numpy arrays
         chroms = np.array(chroms, dtype=CHROMS_DTYPE)
@@ -189,32 +189,6 @@ class Genome(object):
         self.assembly = unicode(assembly)
 
     # -
-
-    @staticmethod
-    def _standardize_chromosomes(chroms):
-        """Convert input chromosomes to a standardized format, add 'chr' prefix if missing,
-
-        Args:
-            chroms (list): A list of chromosome identifiers, either as binary strings or strings.
-
-        Returns:
-            list: A list of standardized chromosome identifiers (strings).
-        """
-            
-        # Case 1: chroms is a list of binary strings
-        if isinstance(chroms[0], bytes):
-            chroms = [x.decode('utf-8') for x in chroms]
-        
-        # Case 2: chroms is a list of integers
-        if isinstance(chroms[0], int):
-            chroms = [str(x) for x in chroms]
-
-        # Add 'chr' prefix to chromosome identifiers if missing
-        for i in range(len(chroms)):
-            if chroms[i][0:3] != 'chr':
-                chroms[i] = 'chr' + chroms[i]
-
-        return chroms
     
     def __eq__(self, other):
         try:
@@ -384,6 +358,32 @@ class Genome(object):
             ggrp.create_dataset("lengths", data=self.lengths,
                                 compression=compression,
                                 compression_opts=compression_opts)
+
+       
+def standardize_chromosomes(chroms):
+    """Convert input chromosomes to a standardized format, add 'chr' prefix if missing,
+
+    Args:
+    chroms (list): A list of chromosome identifiers, either as binary strings or strings.
+
+    Returns:
+    list: A list of standardized chromosome identifiers (strings).
+    """
+
+    # Case 1: chroms is a list of binary strings
+    if isinstance(chroms[0], bytes):
+        chroms = [x.decode('utf-8') for x in chroms]
+
+    # Case 2: chroms is a list of integers
+    if isinstance(chroms[0], int):
+        chroms = [str(x) for x in chroms]
+
+    # Add 'chr' prefix to chromosome identifiers if missing
+    for i in range(len(chroms)):
+        if chroms[i][0:3] != 'chr':
+            chroms[i] = 'chr' + chroms[i]
+
+    return chroms
 
 
 # --------------------

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -160,6 +160,9 @@ class Genome(object):
             chroms = np.array(chroms, dtype=CHROMS_DTYPE)
             lengths = np.array(lengths, dtype=LENGTHS_DTYPE)
             origins = np.array(origins, dtype=ORIGINS_DTYPE)
+        
+        # Change chroms to the appropriate format
+        chroms = self._convert_chroms(chroms)
 
         choices = np.zeros(len(chroms), dtype=bool)
 
@@ -174,6 +177,7 @@ class Genome(object):
                 # if specified with full name, remove chr
                 chrnum = chrnum.replace('chr', '')
                 choices = np.logical_or(chroms == ("chr%s" % chrnum), choices)
+        
         self.chroms = chroms[choices]  # convert to unicode for python2/3 compatibility
         self.origins = origins[choices]
         self.lengths = lengths[choices]
@@ -181,6 +185,20 @@ class Genome(object):
 
     # -
 
+    # Write a private static method to convert the list of chromosomes to the appropriate format
+    @staticmethod
+    def _convert_chroms(chroms):
+        # Case 1: chroms is a list of binary strings
+        if isinstance(chroms[0], bytes):
+            chroms = [x.decode('utf-8') for x in chroms]
+        # If the chromosomes don't start with chr, add it
+        for i in range(len(chroms)):
+            if chroms[i][0:3] != 'chr':
+                chroms[i] = 'chr' + chroms[i]
+        # Convert chroms to numpy array of CHROMS_DTYPE
+        chroms = np.array(chroms, dtype=CHROMS_DTYPE)
+        return chroms
+    
     def __eq__(self, other):
         try:
             return (

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -377,6 +377,11 @@ def standardize_chromosomes(chroms):
     # Case 2: chroms is a list of integers
     if isinstance(chroms[0], int):
         chroms = [str(x) for x in chroms]
+    
+    # Case 3: chroms is a numpy array of strings
+    if isinstance(chroms[0], np.str_):
+        chroms = np.array(chroms, dtype='U10')  # convert to U10
+        chroms = chroms.tolist()  # convert to list
 
     # Add 'chr' prefix to chromosome identifiers if missing
     for i in range(len(chroms)):

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ clscripts = [
 cmdclass.update({'build_ext': build_ext})
 setup(
     name='alabtools',
-    version='1.1.1+coolfix',
+    version='1.1.2',
     author='Nan Hua, Francesco Musella',
     author_email='nhua@usc.edu',
     url='https://github.com/alberlab/alabtools',

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ clscripts = [
 cmdclass.update({'build_ext': build_ext})
 setup(
     name='alabtools',
-    version='1.1.1',
+    version='1.1.1+coolfix',
     author='Nan Hua, Francesco Musella',
     author_email='nhua@usc.edu',
     url='https://github.com/alberlab/alabtools',

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ clscripts = [
 cmdclass.update({'build_ext': build_ext})
 setup(
     name='alabtools',
-    version='1.1.0+bugfix',
+    version='1.1.1',
     author='Nan Hua, Francesco Musella',
     author_email='nhua@usc.edu',
     url='https://github.com/alberlab/alabtools',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ extensions = [
              )
 ]
 
-if '--no-geotools' not in sys.argv:
+# if '--no-geotools' not in sys.argv:
+if not True:  # geotools gives compile issues
     extensions.append(
         Extension("alabtools._geotools", ["alabtools/geotools/geotools.i", "alabtools/geotools/geotools.cpp"],
                   swig_opts=['-c++'],

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ install_requires = [
     'tqdm',
     'six',
     'alphashape>=1.3.1',
-    'trimesh>=3.21.5'
+    'trimesh>=3.21.5',
+    'cooler>=0.8.11'
 ]
 tests_require = [
     'mock'

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,7 @@ extensions = [
              )
 ]
 
-# if '--no-geotools' not in sys.argv:
-if not True:  # geotools gives compile issues
+if '--no-geotools' not in sys.argv:
     extensions.append(
         Extension("alabtools._geotools", ["alabtools/geotools/geotools.i", "alabtools/geotools/geotools.cpp"],
                   swig_opts=['-c++'],

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ clscripts = [
 cmdclass.update({'build_ext': build_ext})
 setup(
     name='alabtools',
-    version='1.1.0',
+    version='1.1.0+bugfix',
     author='Nan Hua, Francesco Musella',
     author_email='nhua@usc.edu',
     url='https://github.com/alberlab/alabtools',

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -1,0 +1,71 @@
+import unittest
+import random
+import numpy as np
+from alabtools.utils import Genome, Index
+from alabtools.api import Contactmatrix
+
+class TestContactmatrix(unittest.TestCase):
+    """Test functions in Contactmatrix
+    """
+    
+    def setUp(self) -> None:
+        return super().setUp()
+    
+    def tearDown(self) -> None:
+        return super().tearDown()
+    
+    def test_sort(self):
+        """Test sort method in Contactmatrix.
+        """
+        # Set genome
+        chroms = ['chr1', 'chr4', 'chr7', 'chr12', 'chr13', 'chrX']
+        assembly = 'mm10'
+        lengths = [random.randint(100, 200) for _ in range(len(chroms))]
+        resolution = 10
+        genome = Genome(assembly=assembly, chroms=chroms, lengths=lengths)
+        # Set index
+        index = genome.bininfo(resolution=resolution)
+        # Create random symmetric matrix
+        matrix = np.random.randint(0, 100, size=(len(index), len(index)))
+        matrix = matrix + matrix.T - np.diag(matrix.diagonal())
+        # Shuffle genome
+        np.random.seed(0)
+        rnd_ord = np.random.permutation(len(chroms))
+        chroms_rnd = [chroms[i] for i in rnd_ord]
+        lengths_rnd = [lengths[i] for i in rnd_ord]
+        genome_rnd = Genome(assembly=assembly, chroms=chroms_rnd, lengths=lengths_rnd)
+        # Shuffle index
+        index_rnd = genome_rnd.bininfo(resolution=resolution)
+        # Shuffle matrix
+        order = np.zeros(len(index), dtype=int)
+        for chrom in chroms_rnd:
+            order[index_rnd.chromstr == chrom] = np.arange(len(index))[index.chromstr == chrom]
+        matrix_rnd = np.copy(matrix)
+        matrix_rnd = matrix_rnd[order, :]
+        matrix_rnd = matrix_rnd[:, order]
+        # Assert shuffling is correct (check intra matrices)
+        for chrom in chroms:
+            np.testing.assert_array_equal(matrix[index.chromstr == chrom, :]
+                                                [:, index.chromstr == chrom],
+                                          matrix_rnd[index_rnd.chromstr == chrom, :]
+                                                    [:, index_rnd.chromstr == chrom])
+
+        # Create Contactmatrix with shuffled genome
+        hcs = Contactmatrix(mat=matrix_rnd, genome=genome_rnd,
+                            resolution=resolution, usechr=('#', 'X', 'Y'))
+        # Sort
+        hcs.sort()
+        # Assert genome
+        np.testing.assert_array_equal(hcs.genome.chroms, chroms)
+        np.testing.assert_array_equal(hcs.genome.lengths, lengths)
+        # Assert index
+        np.testing.assert_array_equal(hcs.index.chromstr, index.chromstr)
+        np.testing.assert_array_equal(hcs.index.start, index.start)
+        np.testing.assert_array_equal(hcs.index.end, index.end)
+        # Assert matrix
+        np.testing.assert_array_equal(hcs.matrix.diagonal, np.diag(matrix))
+        np.testing.assert_array_equal(hcs.matrix.toarray(), matrix)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -12,30 +12,46 @@ class TestGenome(unittest.TestCase):
     def tearDown(self) -> None:
         return super().tearDown()
     
-    def test_init_from_binary_shuffled(self):
-        """Test initialization of Genome object where chroms are given as
-        binary-encoded strings without the 'chr' prefix and are shuffled.
+    def test_init_from_binary(self):
+        """Test initialization of Genome from binary chromosomes.
         """
         # Define the input
         chroms = ['chr1', 'chr2', 'chr3', 'chr10']
         lengths = [2000, 1800, 1500, 1000]
         origins = [0, 10, 0, 0]
+        # Transform chroms to a binary-encoded array without the 'chr'
+        chroms_bnr = [chrom.split('chr')[1] for chrom in chroms]
+        chroms_bnr = [bytes(chrom, 'utf-8') for chrom in chroms_bnr]
+        # Initialize the Genome object
+        genome = Genome(assembly='mm10', chroms=chroms_bnr,
+                        lengths=lengths, origins=origins)
+        # Check the results
+        np.array_equal(genome.chroms, chroms)
+        np.array_equal(genome.lengths, lengths)
+        np.array_equal(genome.origins, origins)
+        
+    
+    def test_sort(self):
+        """Test sorting of the Genome.
+        """
+        # Define the input
+        chroms = ['chr1', 'chr2', 'chr3', 'chr5', 'chr6', 'chr10', 'chr12', 'chr18', 'chrX']
+        lengths = [2000 - 100 * i for i in range(len(chroms))]
+        origins = [0 for _ in range(len(chroms))]
         # Shuffle the input
         idx = list(range(len(chroms)))
         random.shuffle(idx)
         chroms_shuffled = [chroms[i] for i in idx]
         lengths_shuffled = [lengths[i] for i in idx]
         origins_shuffled = [origins[i] for i in idx]
-        # Transform chroms_shuffled to a binary-encoded array without the 'chr'
-        chroms_shuffled = [chrom.split('chr')[1] for chrom in chroms_shuffled]
-        chroms_shuffled = [bytes(chrom, 'utf-8') for chrom in chroms_shuffled]
         # Initialize the Genome object
         genome = Genome(assembly='mm10', chroms=chroms_shuffled,
                         lengths=lengths_shuffled, origins=origins_shuffled)
+        genome.sort(idx)
         # Check the results
-        np.array_equal(genome.chroms, chroms)
-        np.array_equal(genome.lengths, lengths)
-        np.array_equal(genome.origins, origins)
+        np.testing.assert_equal(genome.chroms, chroms)
+        np.testing.assert_equal(genome.lengths, lengths)
+        np.testing.assert_equal(genome.origins, origins)
     
 
 if __name__ == '__main__':

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -1,7 +1,27 @@
 import unittest
 import random
 import numpy as np
-from alabtools.utils import Genome, Index
+from alabtools.utils import Genome, Index, standardize_chromosomes
+
+class TestUtils(unittest.TestCase):
+    """Test functions in utils.py
+    """
+    
+    def setUp(self) -> None:
+        return super().setUp()
+    
+    def tearDown(self) -> None:
+        return super().tearDown()
+    
+    def test_standardize_chromosomes(self):
+        """Test standardize_chromosomes function in utils.
+
+        Returns:
+            _type_: _description_
+        """
+        chroms = [b'1', b'1', b'1', b'2', b'2', b'7', b'X', b'X']
+        chroms_std = ['chr1', 'chr1', 'chr1', 'chr2', 'chr2', 'chr7', 'chrX', 'chrX']
+        np.testing.assert_array_equal(standardize_chromosomes(chroms), chroms_std)
 
 class TestGenome(unittest.TestCase):
     """Test Genome class"""
@@ -31,7 +51,7 @@ class TestGenome(unittest.TestCase):
         np.testing.assert_array_equal(genome.origins, origins)
     
     def test_sort(self):
-        """Test sorting of the Genome.
+        """Test sort method in Genome.
         """
         # Define the input
         chroms = ['chr1', 'chr2', 'chr3', 'chr5', 'chr6', 'chr10', 'chr12', 'chr18', 'chrX']

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -1,0 +1,42 @@
+import unittest
+import random
+import numpy as np
+from alabtools.utils import Genome, Index
+
+class TestGenome(unittest.TestCase):
+    """Test Genome class"""
+    
+    def setUp(self) -> None:
+        return super().setUp()
+    
+    def tearDown(self) -> None:
+        return super().tearDown()
+    
+    def test_init_from_binary_shuffled(self):
+        """Test initialization of Genome object where chroms are given as
+        binary-encoded strings without the 'chr' prefix and are shuffled.
+        """
+        # Define the input
+        chroms = ['chr1', 'chr2', 'chr3', 'chr10']
+        lengths = [2000, 1800, 1500, 1000]
+        origins = [0, 10, 0, 0]
+        # Shuffle the input
+        idx = list(range(len(chroms)))
+        random.shuffle(idx)
+        chroms_shuffled = [chroms[i] for i in idx]
+        lengths_shuffled = [lengths[i] for i in idx]
+        origins_shuffled = [origins[i] for i in idx]
+        # Transform chroms_shuffled to a binary-encoded array without the 'chr'
+        chroms_shuffled = [chrom.split('chr')[1] for chrom in chroms_shuffled]
+        chroms_shuffled = [bytes(chrom, 'utf-8') for chrom in chroms_shuffled]
+        # Initialize the Genome object
+        genome = Genome(assembly='mm10', chroms=chroms_shuffled,
+                        lengths=lengths_shuffled, origins=origins_shuffled)
+        # Check the results
+        np.array_equal(genome.chroms, chroms)
+        np.array_equal(genome.lengths, lengths)
+        np.array_equal(genome.origins, origins)
+    
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -30,28 +30,6 @@ class TestGenome(unittest.TestCase):
         np.array_equal(genome.lengths, lengths)
         np.array_equal(genome.origins, origins)
     
-    def test_get_chromosome_sorting(self):
-        """Test get_chromosome_sorting method.
-        """
-        # Define the input
-        chroms = ['chr1', 'chr2', 'chr3', 'chr5', 'chr6', 'chr10', 'chr12', 'chr18', 'chrX']
-        lengths = [2000 - 100 * i for i in range(len(chroms))]
-        origins = [0 for _ in range(len(chroms))]
-        # Shuffle the input
-        idx = list(range(len(chroms)))
-        random.shuffle(idx)
-        chroms_shuffled = [chroms[i] for i in idx]
-        lengths_shuffled = [lengths[i] for i in idx]
-        origins_shuffled = [origins[i] for i in idx]
-        # Initialize the Genome object
-        genome = Genome(assembly='mm10', chroms=chroms_shuffled,
-                        lengths=lengths_shuffled, origins=origins_shuffled)
-        # Use get_chromosome_sorting method
-        chromorders = genome.get_chromosome_sorting()
-        # Check the results
-        np.testing.assert_equal(list(chromorders.values()), idx)
-        return None    
-    
     def test_sort(self):
         """Test sorting of the Genome.
         """
@@ -68,7 +46,7 @@ class TestGenome(unittest.TestCase):
         # Initialize the Genome object
         genome = Genome(assembly='mm10', chroms=chroms_shuffled,
                         lengths=lengths_shuffled, origins=origins_shuffled)
-        genome.sort(idx)
+        genome.sort()
         # Check the results
         np.testing.assert_equal(genome.chroms, chroms)
         np.testing.assert_equal(genome.lengths, lengths)

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -26,9 +26,9 @@ class TestGenome(unittest.TestCase):
         genome = Genome(assembly='mm10', chroms=chroms_bnr,
                         lengths=lengths, origins=origins)
         # Check the results
-        np.array_equal(genome.chroms, chroms)
-        np.array_equal(genome.lengths, lengths)
-        np.array_equal(genome.origins, origins)
+        np.testing.assert_array_equal(genome.chroms, chroms)
+        np.testing.assert_array_equal(genome.lengths, lengths)
+        np.testing.assert_array_equal(genome.origins, origins)
     
     def test_sort(self):
         """Test sorting of the Genome.
@@ -48,9 +48,32 @@ class TestGenome(unittest.TestCase):
                         lengths=lengths_shuffled, origins=origins_shuffled)
         genome.sort()
         # Check the results
-        np.testing.assert_equal(genome.chroms, chroms)
+        np.testing.assert_array_equal(genome.chroms, chroms)
         np.testing.assert_equal(genome.lengths, lengths)
         np.testing.assert_equal(genome.origins, origins)
+
+class TestIndex(unittest.TestCase):
+    """Test Index class"""
+    
+    def setUp(self) -> None:
+        return super().setUp()
+    
+    def tearDown(self) -> None:
+        return super().tearDown()
+    
+    def test_get_chromint(self):
+        """Test initialization of Genome from binary chromosomes.
+        """
+        # Define the input
+        chromstr = ['chr1', 'chr1', 'chr1', 'chr2', 'chr2', 'chr7', 'chrX', 'chrX']
+        start = [0, 100, 200, 0, 100, 0, 0, 100]
+        end = [100, 200, 300, 100, 200, 100, 100, 200]
+        # Initialize the Index object
+        index = Index(chrom=chromstr, start=start, end=end)
+        # Check the results
+        chromint = [1, 1, 1, 2, 2, 7, 100, 100]
+        np.testing.assert_array_equal(index.get_chromint(), chromint)
+        
     
 
 if __name__ == '__main__':

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -71,6 +71,27 @@ class TestGenome(unittest.TestCase):
         np.testing.assert_array_equal(genome.chroms, chroms)
         np.testing.assert_equal(genome.lengths, lengths)
         np.testing.assert_equal(genome.origins, origins)
+    
+    def test_check_sorted(self):
+        # Define a sorted input
+        chroms = ['chr1', 'chr2', 'chr3', 'chr5', 'chr6', 'chr10', 'chr12', 'chr18', 'chrX', 'chrM']
+        lengths = [2000 - 100 * i for i in range(len(chroms))]
+        origins = [0 for _ in range(len(chroms))]
+        # Create the genome
+        genome = Genome(assembly='mm10', chroms=chroms,
+                        lengths=lengths, origins=origins)
+        # Check the results
+        self.assertTrue(genome.check_sorted())
+        # Define a shuffled input
+        chroms = ['chr1', 'chr6', 'chr13', 'chr7', 'chr2', 'chrX', 'chr12', 'chrM', 'chr18', 'chr5']
+        lengths = [2000 - 100 * i for i in range(len(chroms))]
+        origins = [0 for _ in range(len(chroms))]
+        # Create the genome
+        genome = Genome(assembly='mm10', chroms=chroms,
+                        lengths=lengths, origins=origins)
+        # Check the results
+        self.assertFalse(genome.check_sorted())
+        
 
 class TestIndex(unittest.TestCase):
     """Test Index class"""

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -29,7 +29,28 @@ class TestGenome(unittest.TestCase):
         np.array_equal(genome.chroms, chroms)
         np.array_equal(genome.lengths, lengths)
         np.array_equal(genome.origins, origins)
-        
+    
+    def test_get_chromosome_sorting(self):
+        """Test get_chromosome_sorting method.
+        """
+        # Define the input
+        chroms = ['chr1', 'chr2', 'chr3', 'chr5', 'chr6', 'chr10', 'chr12', 'chr18', 'chrX']
+        lengths = [2000 - 100 * i for i in range(len(chroms))]
+        origins = [0 for _ in range(len(chroms))]
+        # Shuffle the input
+        idx = list(range(len(chroms)))
+        random.shuffle(idx)
+        chroms_shuffled = [chroms[i] for i in idx]
+        lengths_shuffled = [lengths[i] for i in idx]
+        origins_shuffled = [origins[i] for i in idx]
+        # Initialize the Genome object
+        genome = Genome(assembly='mm10', chroms=chroms_shuffled,
+                        lengths=lengths_shuffled, origins=origins_shuffled)
+        # Use get_chromosome_sorting method
+        chromorders = genome.get_chromosome_sorting()
+        # Check the results
+        np.testing.assert_equal(list(chromorders.values()), idx)
+        return None    
     
     def test_sort(self):
         """Test sorting of the Genome.


### PR DESCRIPTION
Fixed a bug when processing a cool file with chromosome named '1', '2', ... (in binary format) instead of 'chr1', 'chr2', ...

Solved by introducing a conversion method that changes the chromosomes in the appropriate format and a sorting method. These methods are called in init.py of Genome.