### PR TITLE
Bugfix_ctenv_popcell

### DIFF
--- a/alabtools/imaging/ctenvelope.py
+++ b/alabtools/imaging/ctenvelope.py
@@ -124,11 +124,11 @@ class CtEnvelope(object):
             assert i in np.arange(self.ncell),\
                 "The input indices must be a subset of the numbers from 0 to ncell-1."
         # remove the cells
-        self.ncell -= len(indices)
         self.cell_labels = np.delete(self.cell_labels, indices)
         self.alpha = np.delete(self.alpha, indices)
         self.mesh = [self.mesh[i] for i in range(self.ncell) if i not in indices]
         self.volume = np.delete(self.volume, indices)
+        self.ncell -= len(indices)
     
     def run(self, cfg):
         """Runs the alpha-shape algorithm.

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ clscripts = [
 cmdclass.update({'build_ext': build_ext})
 setup(
     name='alabtools',
-    version='1.1.2',
+    version='1.1.3',
     author='Nan Hua, Francesco Musella',
     author_email='nhua@usc.edu',
     url='https://github.com/alberlab/alabtools',


### PR DESCRIPTION
Minor bug: in the pop_cells method of ctenvelope, the self.ncell was updated too early, causing a bug in a subsequent loop. 