### PR TITLE
Add_index_sliding

### DIFF
--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -997,7 +997,7 @@ class Index(object):
             raise ValueError(f"Method {method} not available. Choose one of {available_methods}.")
         
         # Get the mapping for the sliding window
-        sliding_mapping = get_index_sliding(self, window)
+        sliding_mapping = get_index_sliding_mapping(self, window)
         
         # Initialize the output index
         out_index = Index(self.chromstr, self.start, self.end, copy=self.copy, genome=self.genome)
@@ -1804,7 +1804,7 @@ def get_index_mappings(idx0, idx1):
     return cmap, fwmap, bwmap
 
 
-def get_index_sliding(index: Index, window: int) -> dict:
+def get_index_sliding_mapping(index: Index, window: int) -> dict:
     """ Get the mapping to perform a sliding window analysis on an Index object.
 
     Args:

--- a/alabtools/utils.py
+++ b/alabtools/utils.py
@@ -1761,6 +1761,49 @@ def get_index_mappings(idx0, idx1):
     return cmap, fwmap, bwmap
 
 
+def get_index_sliding(index: Index, window: int) -> dict:
+    """ Get the mapping to perform a sliding window analysis on an Index object.
+
+    Args:
+        index (Index)
+        window (int): size of the sliding window in units of the index resolution.
+                      If even, it is increased by 1.
+
+    Returns:
+        dict: dictionary that maps each segment of the index to the respective segments of their sliding windows.
+    """
+    
+    # Check that the window size is valid
+    if not isinstance(window, int):
+        raise TypeError("The input window must be an integer.")
+    if not window > 0:
+        raise ValueError("The input window must be a positive integer.")
+    if not window % 2:
+        window += 1
+    
+    # Initialize the mapping dictionary
+    mapping = {}
+    
+    # Map each segment of the index to the respective segments of their sliding windows
+    for i in range(len(index)):
+        
+        # Get the start and end positions of the sliding window of the current segment i
+        s = i - (window - 1) // 2
+        e = i + (window - 1) // 2  # the end must be included in the window
+        
+        # If s is outside the index, or outside the chromosome of i, change it to the start of the chromosome
+        if s < 0 or index.chromstr[s] != index.chromstr[i] or index.copy[s] != index.copy[i]:
+            s = np.where(np.logical_and(index.chromstr == index.chromstr[i], index.copy == index.copy[i]))[0][0]
+        # If e is outside the index, or outside the chromosome of i, change it to the end of the chromosome
+        if e >= len(index) or index.chromstr[e] != index.chromstr[i] or index.copy[e] != index.copy[i]:
+            e = np.where(np.logical_and(index.chromstr == index.chromstr[i], index.copy == index.copy[i]))[0][-1]
+        
+        # Add the mapping to the dictionary
+        mapping[i] = np.arange(s, e + 1)
+    
+    return mapping
+
+
 def region_intersect(b, e, x, y):
     a = x < e
     b = y > b

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ clscripts = [
 cmdclass.update({'build_ext': build_ext})
 setup(
     name='alabtools',
-    version='1.1.17+add_index_sliding',
+    version='1.1.18',
     author='Nan Hua, Francesco Musella',
     author_email='nhua@usc.edu',
     url='https://github.com/alberlab/alabtools',

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ clscripts = [
 cmdclass.update({'build_ext': build_ext})
 setup(
     name='alabtools',
-    version='1.1.17',
+    version='1.1.17+add_index_sliding',
     author='Nan Hua, Francesco Musella',
     author_email='nhua@usc.edu',
     url='https://github.com/alberlab/alabtools',

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -293,7 +293,7 @@ class TestIndex(unittest.TestCase):
         index = Index(chrom=chromstr, start=start, end=end, genome=Genome('mm10', usechr=('chr1', 'chr2', 'chr3', 'chrX')))
         
         # Get the sliding index
-        index_sliding = get_index_sliding(index, window=3)
+        index_sliding = get_index_sliding_mapping(index, window=3)
         
         # Test the results
         real_sliding = {

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -268,6 +268,52 @@ class TestIndex(unittest.TestCase):
         np.testing.assert_array_almost_equal(index.track1, y[chromstr != 'chrX'])
         # Delete the file
         os.remove('test.bed')
+    
+    def test_get_index_sliding(self):
+        """ Test get_index_sliding function."""
+        
+        # Initialize the Index manually
+        chromstr = np.array(
+            [
+                'chr1', 'chr1', 'chr1', 'chr1', 'chr1', 'chr1',
+                'chr2', 'chr2', 'chr2', 'chr2',
+                'chr3', 'chr3', 'chr3',
+                'chrX'
+            ]
+        ).astype('U20')
+        start = np.array(
+            [
+                0, 100, 200, 300, 400, 500,
+                0, 100, 200, 300,
+                0, 100, 200,
+                0
+            ]
+        ).astype(int)
+        end = start + 100
+        index = Index(chrom=chromstr, start=start, end=end, genome=Genome('mm10', usechr=('chr1', 'chr2', 'chr3', 'chrX')))
+        
+        # Get the sliding index
+        index_sliding = get_index_sliding(index, window=3)
+        
+        # Test the results
+        real_sliding = {
+            0: np.array([0, 1]),
+            1: np.array([0, 1, 2]),
+            2: np.array([1, 2, 3]),
+            3: np.array([2, 3, 4]),
+            4: np.array([3, 4, 5]),
+            5: np.array([4, 5]),
+            6: np.array([6, 7]),
+            7: np.array([6, 7, 8]),
+            8: np.array([7, 8, 9]),
+            9: np.array([8, 9]),
+            10: np.array([10, 11]),
+            11: np.array([10, 11, 12]),
+            12: np.array([11, 12]),
+            13: np.array([13])
+        }
+        for i in real_sliding:
+            np.testing.assert_array_equal(index_sliding[i], real_sliding[i])
 
 
 def shuffle_in_place(arrays):


### PR DESCRIPTION
methods added to perform a sliding-window operations on indices. The main method is called get_index_sliding_mapping, and provides for each segment of the index the indices associated with its sliding window: this mapping makes sure that no segments of different chromosomes or copies are included in the window. A method that uses this function and calculates sliding mean, median or sum is added in the Index. A test function for the mapping has been included.