### PR TITLE
Fix_coarsegrain

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ clscripts = [
 cmdclass.update({'build_ext': build_ext})
 setup(
     name='alabtools',
-    version='1.1.22+fix_coarsegrain',
+    version='1.1.23',
     author='Nan Hua, Francesco Musella',
     author_email='nhua@usc.edu',
     url='https://github.com/alberlab/alabtools',

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ clscripts = [
 cmdclass.update({'build_ext': build_ext})
 setup(
     name='alabtools',
-    version='1.1.22',
+    version='1.1.22+fix_coarsegrain',
     author='Nan Hua, Francesco Musella',
     author_email='nhua@usc.edu',
     url='https://github.com/alberlab/alabtools',

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -192,7 +192,8 @@ class TestIndex(unittest.TestCase):
         self.assertTrue(index.consecutive())
     
     def test_coarsegrain(self):
-        """Test coarsegrain method in Index."""
+        """Test coarsegrain method in Index.
+        This test should be rewritten to be more easy."""
         in_res, out_res = 10, 20
         # Generate domains
         genome, chromstr, start, end, _, x, y = generate_domains(resolution=in_res)

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -193,7 +193,7 @@ class TestIndex(unittest.TestCase):
     
     def test_coarsegrain(self):
         """Test coarsegrain method in Index."""
-        in_res, out_res = 22, 44
+        in_res, out_res = 10, 20
         # Generate domains
         genome, chromstr, start, end, _, x, y = generate_domains(resolution=in_res)
         # Remove consecutive domains


### PR DESCRIPTION
The coarsegrain method had an issue: it didn't adjust the origins of the genome object. This is an issue when, for example, we coarse-grain from 25kb to 50kb and the origin of chr1 is 3025000. In this case, we want the origin to become 3000000. I have made this adjustment. 