### PR TITLE
Expand_index_hashmap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ clscripts = [
 cmdclass.update({'build_ext': build_ext})
 setup(
     name='alabtools',
-    version='1.1.26+expand_index_hashmap',
+    version='1.1.27',
     author='Nan Hua, Francesco Musella',
     author_email='nhua@usc.edu',
     url='https://github.com/alberlab/alabtools',

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ clscripts = [
 cmdclass.update({'build_ext': build_ext})
 setup(
     name='alabtools',
-    version='1.1.26',
+    version='1.1.26+expand_index_hashmap',
     author='Nan Hua, Francesco Musella',
     author_email='nhua@usc.edu',
     url='https://github.com/alberlab/alabtools',

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -151,10 +151,17 @@ class TestIndex(unittest.TestCase):
     def test_get_index_hashmap(self):
         """Test get_index_hashmap method in Index."""
         res = 22
+        # Generate the domains
         genome, chromstr, start, end, _, _, _ = generate_domains(resolution=res)
+        # Generate random gene_labels
+        gene_labels = np.array(['gene' + str(i) for i in range(len(chromstr))])
         index = Index(chrom=chromstr, start=start, end=end, genome=genome)
-        hashmap = index.get_index_hashmap()
-        for i, dom in enumerate(zip(chromstr, start, end)):
+        # Add gene_labels as a custom track
+        index.add_custom_track('gene_labels', gene_labels)
+        # Get the index hashmap
+        hashmap = index.get_index_hashmap(extra_cols=['gene_labels'])
+        # Test the results
+        for i, dom in enumerate(zip(chromstr, start, end, gene_labels)):
             self.assertEqual(hashmap[dom], [i])
     
     def test_sort_by_chromosome(self):

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -273,7 +273,7 @@ class TestIndex(unittest.TestCase):
         random.shuffle(domain_set)
         domain_set = set(domain_set)
         # Create the index
-        index = get_index_from_set(domain_set, assembly=genome.assembly)
+        index = get_index_from_set(domain_set, assembly=genome.assembly, extra_cols=['gene_labels'], extra_types=[str])
         # Test the results
         np.testing.assert_array_equal(index.chromstr, chromstr)
         np.testing.assert_array_equal(index.start, start)


### PR DESCRIPTION
I expanded get_index_hashmap. Now it allows to create domains by including data from extra tracks. For example, if 'gene_labels' is a valid custom track in the index, a domain would be ('chr1', 0, 100, 'gene1').

I also fixed get_index_from_set: now the dimension of the input set of domain can be > 4, and the extra columns can be saved with input track names and dtypes.

Tests for both have been updated.