### PR TITLE
New_install_info

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ See also our Integrative Genome Modeling (IGM) software package: https://github.
 ATTENTION: This package should work on both Linux and MacOS systems. It has been tested on CentOS 7.9.2009 (Core) and on Mac Tahoe 26.2.
 
 Make sure you have conda installed (https://docs.conda.io/en/latest/miniconda.html) and that you have added the conda-forge channel (https://conda-forge.org/).
+We recommend using conda ≥ 24. Older versions may stall during installation of some packages.
+
+This package relies on some C++ codes, requiring a C++ compiler installed on your system. If you're using an old GCC version (e.g. GCC 4.x),
+please consider updating it if you encounter compilation errors during installation. Although we haven't tested it systematically, GCC > 9 should work fine.
 
 Create a conda environment with a Python 3.11 version.
 ```bash
@@ -18,7 +22,7 @@ conda activate alab
 Then, install the following packages with conda forge:
 ```bash
 conda install -c conda-forge \
-    numpy \
+    numpy<2.4 \
     scipy \
     pandas \
     h5py \
@@ -33,6 +37,9 @@ conda install -c conda-forge \
     -y
 ```
 
+NOTE 1: The numpy version must be less than 2.4, otherwise some scripts will raise errors.
+NOTE 2: If you're having touble installing these packages simultaneously, try installing them one by one or in smaller batches. 
+
 Then install another set of packages with pip:
 ```bash
 pip install cooler pyBigWig
@@ -46,4 +53,5 @@ pip install git+https://github.com/alberlab/alabtools.git
 If the install fails with build-isolation / NumPy build errors (common on older HPC systems):
 ```bash
 pip install git+https://github.com/alberlab/alabtools.git --no-build-isolation
+
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=64", "wheel", "Cython>=3.0", "numpy"]
+requires = ["setuptools>=64", "wheel", "Cython>=3.0", "numpy>=1.23,<2.4"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ import sys
 
 # Add include and library directories from conda envs for swig.
 std_include = [sys.prefix + '/include', sys.prefix + '/Library/include']
-std_library = [sys.prefix + '/lib', sys.prefix + '/Library/lib']
 
 # Obtain the numpy include directory.  This logic works across numpy versions.
 try:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ except AttributeError:
 cmdclass = {}
 python_requires = '>=3.11'
 install_requires = [
-    'numpy>=1.23,<3',
+    'numpy>=1.23,<2.4',
     'scipy>=1.10',
     'pandas>=2.0',
     'h5py>=3.8',

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ clscripts = [
 cmdclass.update({'build_ext': build_ext})
 setup(
     name='alabtools',
-    version='1.1.29',
+    version='1.1.29+fix_install_info',
     author='Nan Hua, Francesco Musella',
     author_email='nhua@usc.edu',
     url='https://github.com/alberlab/alabtools',

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ clscripts = [
 cmdclass.update({'build_ext': build_ext})
 setup(
     name='alabtools',
-    version='1.1.29+fix_install_info',
+    version='1.1.30',
     author='Nan Hua, Francesco Musella',
     author_email='nhua@usc.edu',
     url='https://github.com/alberlab/alabtools',


### PR DESCRIPTION
- numpy version capped at 2.3: 2.4 or higher would give errors in some scripts
- notes added in README about the versions of conda and GCC
- notes added about potentially installing the libraries with conda in batches
- unused variable removed setup.py